### PR TITLE
feature: Build out CRUD operation on assignment

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+./.DS_Store
 .env.local
 .env.development.local
 .env.test.local

--- a/backend/src/api/index.js
+++ b/backend/src/api/index.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import UserController from "../controllers/users";
 import ClassController from "../controllers/classes";
+import AssignmentController from "../controllers/assignments";
 
 const router = Router();
 
@@ -8,5 +9,6 @@ const router = Router();
 router.get("/", (_, res) => res.send("v18 Bears API"));
 router.use("/user", UserController);
 router.use("/class", ClassController);
+router.use("/assignment", AssignmentController);
 
 export default router;

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ import createError from "http-errors";
 import morganBody from "morgan-body";
 import api from "./api";
 import mongoManager from "./mongo";
+import trimmer from './helper';
 
 const app = express();
 
@@ -27,9 +28,10 @@ app.use(
         : "https://productionUrlHere.now.sh",
   })
 );
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-
+app.use(trimmer);
 // use all routes exported from the routes folder
 app.use("/api", api);
 

--- a/backend/src/controllers/assignments/controllers.js
+++ b/backend/src/controllers/assignments/controllers.js
@@ -1,0 +1,97 @@
+import Assignment from "../../models/assignments";
+import createError from "http-errors";
+import User, { userRole } from "../../models/users";
+import Class from "../../models/classes";
+
+export const createAssignment = async (req, res, next) => {
+  try {
+    const { teacherName, classId } = req.body;
+
+    //User validation
+    const user = await User.findOne({ userName: teacherName });
+    if (!user) throw createError(404, `Teacher ${teacherName} not found`);
+
+    //Authorization Validation
+    if (user.role != userRole.TEACHER) {
+      throw createError(404, `User ${teacherName} is not a Teacher`);
+    }
+
+    //validate if class exist
+    const existingClass = await Class.findById(classId);
+    if (!existingClass)
+      throw createError(404, `Claas ${classId} dose not exist`);
+
+    //create a new Assignment
+    const assignment = await Assignment.create(req.body);
+    //response object
+    res.status(201).json({
+      msg: "Assignment created",
+      assignment,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getAllAssignment = async(_req, res, next) => {
+    try {
+    const assignments = await Assignment.find().lean();
+    if(!assignments)throw err;
+    res.status(200).json(assignments);
+    } catch (err) {
+    next(err)
+    }
+}
+export const getAssignmentById = async (req, res, next) => {
+    try {
+      const { assignmentId } = req.params;
+      const activeAssigment = await Assignment.findById(assignmentId);
+      console.log(activeAssigment, 'active')
+      if (!activeAssigment)
+        throw createError(404, `Assignment with Id ${assignmentId} not found`);
+      res.status(200).json(activeAssigment);
+    } catch (err) {
+      next(err);
+    }
+  };
+
+  export const updateAssignment = async (req, res, next) =>{
+      try {
+        const { assignmentId } = req.params;
+       
+        //validate if assignment exist in DB
+        const validateId = await Assignment.findById(assignmentId);
+
+        if(!validateId) throw createError(404, `Assignment id ${assignmentId} does not exist`);
+
+        //Update the existing assignment
+        const newAssignment = await Assignment.insertMany(req.body);
+        res.status(200).json({
+            msg: 'Assignment Updated Successfully',
+            newAssignment
+        })
+      } catch (err) {
+          next(err)
+      
+      };
+  }
+
+  export const deleteSingleAssignmentById = async(req, res, next) =>{
+      try {
+        const { assignmentId } = req.params;
+
+        //Validate if assignment exist in DB
+        const validateId = await Assignment.findById(assignmentId);
+        if(!validateId) throw createError(404, `Assignment Id ${assignmentId} does not exist`);
+
+        //Delete assignment from DB
+         await Assignment.deleteOne({_id: assignmentId});
+         res.status(200).json({
+             msg: `Assignment Deleted Successfully`
+         })
+      } catch (err) {
+      next(err)
+      }
+     
+  }
+  

--- a/backend/src/controllers/assignments/index.js
+++ b/backend/src/controllers/assignments/index.js
@@ -1,0 +1,2 @@
+import router from './routes';
+export default router;

--- a/backend/src/controllers/assignments/routes.js
+++ b/backend/src/controllers/assignments/routes.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+
+import { 
+createAssignment,
+getAllAssignment,
+getAssignmentById,
+updateAssignment,
+deleteSingleAssignmentById,
+} from './controllers';
+
+const router = Router();
+router.get("", getAllAssignment);
+router.get("/:assignmentId", getAssignmentById)
+router.post("/", createAssignment);
+router.put("/:assignmentId", updateAssignment);
+router.delete("/:assignmentId", deleteSingleAssignmentById);
+
+export default router;

--- a/backend/src/helper/index.js
+++ b/backend/src/helper/index.js
@@ -1,0 +1,13 @@
+//Middleware function to trim a input string
+const trimmer = (_req, res, next) => {
+    const { body } = _req;
+  
+    Object.keys(body).forEach(val => {
+      if (typeof body[val] === 'string') {
+        body[val] = body[val].trim();
+      }
+    });
+    return next();
+  };
+  
+  export default trimmer;

--- a/backend/src/models/assignments/index.js
+++ b/backend/src/models/assignments/index.js
@@ -1,0 +1,2 @@
+import Assignment from './schema';
+export default Assignment;

--- a/backend/src/models/assignments/schema.js
+++ b/backend/src/models/assignments/schema.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose';
+const Schema = mongoose.Schema;
+
+const assignmentSchema = new Schema({
+    classId: {
+        type: String,
+        required: true
+    },
+      title: {
+          type: String,
+          required: true,
+          validate: async (value) => {
+            try {
+                const result = await Assignment.findOne({ title: value })
+                if (result) throw new Error("duplicity detected: title :" + value);
+            } catch (error) {
+                throw new Error(error);
+            }
+        }
+      },
+      description:{
+          type: String,
+          required: true
+      },
+      startDate: {
+          type: Date,
+          default: null
+      },
+      endDate: {
+          type: Date,
+          default: null
+      }
+});
+
+const Assignment = mongoose.model("Assignment", assignmentSchema);
+export default Assignment;
+


### PR DESCRIPTION
#### Description
Teachers are not enabled to create an assignment on the application before this PR. This PR ensures that Teachers can create an assignment, update an assignment, get all assignments, get an assignment by an ID, and delete an assignment.

#### Type of change
 Assignment endpoints
- [x] create an assignment
- [x] get a single assignment
- [x] get all assignment
- [x] update an assignment by an Id
- [x] Delete an assignment by an id

#### How Has This Been Tested?
- clone this repo
- checkout to this branch by running `npm checkout ft-assignment`
- start the `Server` using `npm start`
-  goto postman and test the endpoints as follows
- POST: localhost://5000/api/assignment
- GET: localhost://5000/api/assignment
- GET: localhost://5000/api/assignment/:assignmentId
- PUT: localhost://5000/api/assignment/:assignmentId
- DELETE: localhost://5000/api/assignment/:assignmentId

- [] Unit testing
N/A
#### Checklist:
N/A
#### PT-ID
N/A
[](url)
N/A